### PR TITLE
Extensions on Windows are commented by default

### DIFF
--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -5,7 +5,7 @@ anchor:  windows_setup
 
 ## Windows Setup {#windows_setup_title}
 
-You can download the binaries from [windows.php.net/download][php-downloads]. After the extraction of PHP, it is recommended to set the [PATH][windows-path] to the root of your PHP folder (where php.exe is located) so you can execute PHP from anywhere.
+You can download the binaries from [windows.php.net/download][php-downloads]. After the extraction of PHP, it is recommended to set the [PATH][windows-path] to the root of your PHP folder (where php.exe is located) so you can execute PHP from anywhere. There is no `php.ini` in the distribution package, but you can just rename `php.ini-development` to `php.ini`. Also, in contrast to the default settings of many Linux distributions, all of the extensions are disabled by default and need to be uncommented in `php.ini`. 
 
 For learning and local development, you can use the built in webserver with PHP 5.4+ so you don't need to worry about
 configuring it. If you would like an "all-in-one" which includes a full-blown webserver and MySQL too then tools such

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -5,7 +5,7 @@ anchor:  windows_setup
 
 ## Windows Setup {#windows_setup_title}
 
-You can download the binaries from [windows.php.net/download][php-downloads]. After the extraction of PHP, it is recommended to set the [PATH][windows-path] to the root of your PHP folder (where php.exe is located) so you can execute PHP from anywhere. There is no `php.ini` in the distribution package, but you can just rename `php.ini-development` to `php.ini`. Also, in contrast to the default settings of many Linux distributions, all of the extensions are disabled by default and need to be uncommented in `php.ini`. 
+You can download the binaries from [windows.php.net/download][php-downloads]. After the extraction of PHP, it is recommended to set the [PATH][windows-path] to the root of your PHP folder (where php.exe is located) so you can execute PHP from anywhere. There is no `php.ini` in the distribution package, but you can just rename `php.ini-development` to `php.ini`. In contrast to the default settings of many Linux distributions, all of the extensions are disabled by default and need to be uncommented in `php.ini`. Also, the `extension_dir` must be set to `ext` directory in your PHP folder.
 
 For learning and local development, you can use the built in webserver with PHP 5.4+ so you don't need to worry about
 configuring it. If you would like an "all-in-one" which includes a full-blown webserver and MySQL too then tools such


### PR DESCRIPTION
PHP packages on many Linux systems have basic extensions (`php_mysqli`, `php_openssl` and such) enabled by default. It has been unexpected for me, that Windows distribution package has all the extensions disabled even though they are present in the `ext` directory. 